### PR TITLE
removed xunit parameter in create_base_plot function

### DIFF
--- a/calocem/utils.py
+++ b/calocem/utils.py
@@ -121,7 +121,7 @@ def read_excel(file, show_info=True):
         return None
 
 
-def create_base_plot(data, ax, _age_col, _target_col, sample, xunit):
+def create_base_plot(data, ax, _age_col, _target_col, sample):
     """
     create base plot
     """


### PR DESCRIPTION
Removed the xunit parameter in the create_base_plot function, otherwise the example from the docs yields an error missing a argument: # here you need to define the suitable path to the data
# this reads a little cryptic because it is a relative path from the docs folder of the repo
datapath = Path().cwd().parent / "calocem" / "DATA"

tam = Measurement(datapath, regex=".*bm2.csv")

fig, ax = plt.subplots()
tam.plot(ax=ax)
ax.set_xlim(0, 30)
ax.set_ylim(0, 5)
ax.set_title("TACalorimetry Measurement")
plt.show()