### PR TITLE
  feat: add save_cache kwarg to Measurement (default False)                                                                                            

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Pickle caching is now opt-in.** `Measurement(folder=...)` no longer writes
+  `_data.pickle` and `_info.pickle` to the working directory by default. Pass
+  `save_cache=True` explicitly to enable it.
+
+  Migrate:
+
+  ```python
+  # old (implicit caching)
+  m = Measurement(folder)
+
+  # new — equivalent caching behavior
+  m = Measurement(folder, save_cache=True)
+  ```
+
+### Added
+
+- **`save_cache: bool = False` kwarg on `Measurement.__init__`.** Controls whether
+  pickle cache files are written when loading from a folder. The existing
+  `cold_start=False` read path is unchanged.
+
 ## [0.3.0] - 2026-04-03
 
 ### Breaking Changes

--- a/calocem/measurement.py
+++ b/calocem/measurement.py
@@ -52,6 +52,7 @@ class Measurement:
         processed: bool = False,
         metadata_path: Optional[Union[str, pathlib.Path]] = None,
         metadata_id_column: Optional[str] = None,
+        save_cache: bool = False,
     ):
         """
         Initialize measurements from folder or existing data.
@@ -78,6 +79,11 @@ class Measurement:
             Path to metadata file (CSV, Excel, etc.), by default None
         metadata_id_column : str, optional
             Column name in metadata file that matches sample names, by default None
+        save_cache : bool, optional
+            Whether to write `_data.pickle` and `_info.pickle` cache files when loading
+            from a folder, by default False. When True, subsequent runs can be sped up
+            with ``cold_start=False`` to read from the cache instead of re-parsing the
+            folder. When False (default), no pickle files are created.
         """
         # Initialize attributes
         self._data = pd.DataFrame()
@@ -89,6 +95,7 @@ class Measurement:
         # Store configuration
         self._new_code = new_code
         self._processed = processed
+        self._save_cache = save_cache
 
         # Setup processing parameters
         if not isinstance(processparams, ProcessingParameters):
@@ -148,8 +155,9 @@ class Measurement:
             )
             self._data_unprocessed = self._data.copy()
 
-            # Save to cache
-            self._data_persistence.save_data(self._data, self._info)
+            # Save to cache only if requested
+            if self._save_cache:
+                self._data_persistence.save_data(self._data, self._info)
 
         except Exception as e:
             raise DataProcessingException("load_from_folder", e)

--- a/tests/test_save_cache.py
+++ b/tests/test_save_cache.py
@@ -1,0 +1,43 @@
+import pathlib
+import shutil
+
+import pytest
+
+from calocem.measurement import Measurement
+
+
+DATA_DIR = pathlib.Path(__file__).parent.parent / "calocem" / "DATA"
+SAMPLE = "excel_example4.xls"
+
+
+def _run_measurement(tmp_path, monkeypatch, **kwargs):
+    monkeypatch.chdir(tmp_path)
+    return Measurement(DATA_DIR, regex=SAMPLE, show_info=False, **kwargs)
+
+
+def test_default_does_not_write_pickles(tmp_path, monkeypatch):
+    _run_measurement(tmp_path, monkeypatch)
+    assert not (tmp_path / "_data.pickle").exists()
+    assert not (tmp_path / "_info.pickle").exists()
+
+
+def test_save_cache_true_writes_pickles(tmp_path, monkeypatch):
+    _run_measurement(tmp_path, monkeypatch, save_cache=True)
+    assert (tmp_path / "_data.pickle").exists()
+    assert (tmp_path / "_info.pickle").exists()
+
+
+def test_cold_start_false_reads_existing_cache(tmp_path, monkeypatch):
+    primed = _run_measurement(tmp_path, monkeypatch, save_cache=True)
+    primed_data = primed.get_data()
+
+    reloaded = Measurement(DATA_DIR, regex=SAMPLE, show_info=False, cold_start=False)
+    assert reloaded.get_data().equals(primed_data)
+
+
+def test_save_cache_false_with_cold_start_false_raises(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from calocem.exceptions import ColdStartException
+
+    with pytest.raises(ColdStartException):
+        Measurement(DATA_DIR, regex=SAMPLE, show_info=False, cold_start=False)


### PR DESCRIPTION
## Summary                                                                                                                                             
            
  Make pickle-cache writing opt-in. Previously `Measurement(folder=...)` unconditionally wrote `_data.pickle` and `_info.pickle` to the current working   directory on every load. The new `save_cache: bool = False` kwarg gates the write; the existing `cold_start=False` read path is unchanged.             
                                                                                                                                            
  ## Behavior change                                                                                                                                     
                                                                                                                                                       
  This is a deliberate behavior change: callers that relied on a pickle being written for a later `cold_start=False` run must now pass `save_cache=True`
  explicitly. For typical interactive use this is an improvement — no more stray pickles in the working directory.                                       
                                                                                                                  
  Migration for existing users:                                                                                                                          
                                                                                                                                                       
  ```python
  # Before (implicit caching)                                                                                                                            
  m = Measurement(folder)    
                                                                                                                                                         
  # After, if you want caching
  m = Measurement(folder, save_cache=True)
                                                                                                                                                         
  Test plan
                                                                                                                                                         
  - tests/test_save_cache.py covers four cases:                                                                                                          
    - default writes no pickles
    - save_cache=True writes both pickle files                                                                                                           
    - cold_start=False reads back data written by a prior save_cache=True run                                                                            
    - cold_start=False with no prior cache raises ColdStartException                                                                                     
  - Full suite still passes (23/23 locally)   