### PR TITLE
docs: clean up stale package-rename leftovers in docs/ 

### DIFF
--- a/docs/how-to-guide.md
+++ b/docs/how-to-guide.md
@@ -1,16 +1,16 @@
-![Logo](https://github.com/mj-hofmann/TAInstCalorimetry/blob/main/icon/icon.png?raw=true)
+![Logo](https://github.com/mj-hofmann/CaloCem/blob/main/icon/icon.png?raw=true)
 
 # Interfacing with experimental results file from TAM Air calorimeters made easy.
 
-After collecting multiple experimental results files from a TAM Air calorimeter you will be left with multiple *.xls*-files obtained as exports from the device control software. To achieve a side by side comparison of theses results and some basic extraction of relevant parameters, **TAInstCalorimetry** is here to get this done smoothly.
+After collecting multiple experimental results files from a TAM Air calorimeter you will be left with multiple *.xls*-files obtained as exports from the device control software. To achieve a side by side comparison of theses results and some basic extraction of relevant parameters, **CaloCem** is here to get this done smoothly.
 
-*Note: **TAInstCalorimetry** has been developed without involvement of **TA Instruments** and is thus independent from the company and its software.*
+*Note: **CaloCem** has been developed without involvement of **TA Instruments** and is thus independent from the company and its software.*
 
 ## Info / Downloads
 
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/tainstcalorimetry.svg?color=blue&label=Downloads&logo=pypi&logoColor=gold)](https://pepy.tech/project/tainstcalorimetry)
-[![PyPI - Downloads](https://static.pepy.tech/personalized-badge/tainstcalorimetry?period=total&units=none&left_color=black&right_color=grey&left_text=Downloads)](https://pepy.tech/project/tainstcalorimetry)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/tainstcalorimetry.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/tainstcalorimetry/) 
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/calocem.svg?color=blue&label=Downloads&logo=pypi&logoColor=gold)](https://pepy.tech/project/calocem)
+[![PyPI - Downloads](https://static.pepy.tech/personalized-badge/calocem?period=total&units=none&left_color=black&right_color=grey&left_text=Downloads)](https://pepy.tech/project/calocem)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/calocem.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/calocem/) 
 
 ## Table of Contents  
 - [Example Usage](#example-usage)<br>
@@ -62,7 +62,7 @@ plt.show()
 
 Without further options specified, the ```plot()```-method yields the following.
 
-![enter image description here](https://github.com/mj-hofmann/TAInstCalorimetry/blob/main/tests/plots/Figure%202022-08-08%20112743.png?raw=true)
+![enter image description here](https://github.com/mj-hofmann/CaloCem/blob/main/tests/plots/Figure%202022-08-08%20112743.png?raw=true)
 
 The ```plot()```-method can also be tuned to show the temporal course of normalized heat. On the one hand, this "tuning" refers to the specification of further keyword arguments such as ```t_unit``` and ```y```. On the other hand, the ```plot()```-method returns an object of type ```matplotlib.axes._subplots.AxesSubplot```, which can be used to further customize the plot. In the following, a guide-to-the-eye line is introduced next to adjuting the axes limts, which is not provided for via the ```plot()```-method's signature.
 
@@ -88,7 +88,7 @@ plt.show()
 ```
 The following plot is obtained:
 
-![enter image description here](https://github.com/mj-hofmann/TAInstCalorimetry/blob/main/tests/plots/Figure%202022-08-19%20085928.png?raw=true)
+![enter image description here](https://github.com/mj-hofmann/CaloCem/blob/main/tests/plots/Figure%202022-08-19%20085928.png?raw=true)
 
 ### Getting cumulated heat values
 
@@ -125,9 +125,9 @@ peaks = tam.get_peaks(
 
 Tweaking some of the available keyword arguments, the following plot is obtained:
 
-![Identified peaks for one sample.](https://github.com/mj-hofmann/TAInstCalorimetry/blob/main/tests/plots/Figure%202023-01-25%20193222.png?raw=true)
+![Identified peaks for one sample.](https://github.com/mj-hofmann/CaloCem/blob/main/tests/plots/Figure%202023-01-25%20193222.png?raw=true)
 
-Please keep in mind, that in particular for samples of ordinary Portland cement (OPC) a clear and unambiguous identification/assigment of peaks remains a challenging task which cannot be achieved in each and every case by **TAInstCalorimetry**. It is left to the user draw meaningful scientific conclusions from the characteristics derived from this method.
+Please keep in mind, that in particular for samples of ordinary Portland cement (OPC) a clear and unambiguous identification/assigment of peaks remains a challenging task which cannot be achieved in each and every case by **CaloCem**. It is left to the user draw meaningful scientific conclusions from the characteristics derived from this method.
 
 ### Identifying peak onsets
 
@@ -143,7 +143,7 @@ onsets = tam.get_peak_onsets(
     regex="OPC"
 )
 ```
-![Identified peak onsets for one sample.](https://github.com/mj-hofmann/TAInstCalorimetry/blob/main/tests/plots/Figure%202023-01-26%20174524.png?raw=true)
+![Identified peak onsets for one sample.](https://github.com/mj-hofmann/CaloCem/blob/main/tests/plots/Figure%202023-01-26%20174524.png?raw=true)
 
 ### Plotting by Category
 
@@ -192,13 +192,13 @@ for this_plot in tam.plot_by_category(categorize_by):
 
 This yields plots of the following kind.
 
-![Identified peak onsets for one sample.](https://github.com/mj-hofmann/TAInstCalorimetry/blob/main/tests/plots/Figure%202023-03-20%20170659.png?raw=true)
+![Identified peak onsets for one sample.](https://github.com/mj-hofmann/CaloCem/blob/main/tests/plots/Figure%202023-03-20%20170659.png?raw=true)
 
-![Identified peak onsets for one sample.](https://github.com/mj-hofmann/TAInstCalorimetry/blob/main/tests/plots/Figure%202023-03-20%20170711.png?raw=true)
+![Identified peak onsets for one sample.](https://github.com/mj-hofmann/CaloCem/blob/main/tests/plots/Figure%202023-03-20%20170711.png?raw=true)
 
 ## Installation
 
-Use the package manager [pip](https://pip.pypa.io/en/stable/) to install TAInstCalorimetry.
+Use the package manager [pip](https://pip.pypa.io/en/stable/) to install CaloCem.
 
 ```bash
 pip install CaloCem
@@ -218,7 +218,7 @@ List of contributors
 
 
 ## Test
-![Tests](https://github.com/mj-hofmann/TAInstCalorimetry/actions/workflows/run-tests.yml/badge.svg)
+![Tests](https://github.com/mj-hofmann/CaloCem/actions/workflows/run-tests.yml/badge.svg)
 
 ## Code Styling
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 This site contains the project documentation and serves as your starting point
-for working with the `TAInstCalorimetry` packaga made available 
-on [PyPI](https://pypi.org/project/tainstcalorimetry/).
+for working with the `CaloCem` package made available 
+on [PyPI](https://pypi.org/project/calocem/).
 
 ## Table Of Contents
 

--- a/docs/quantification.md
+++ b/docs/quantification.md
@@ -62,7 +62,7 @@ The dataframe looks like this:
 
 Programmatic, automatic detection the maximum slope can be a little tricky.
 The first example is straightforward and looks a normal Portland cement hydration case.
-Assuming that the data is already loaded, we can inistantiate the ProcessingParameters object.
+Assuming that the data is already loaded, we can instantiate the ProcessingParameters object.
 The algorithm detects the maxima of the gradient of the heat flow.
 It is therefore very useful to apply a little smoothing to the first derivative.
 

--- a/docs/tian.md
+++ b/docs/tian.md
@@ -6,7 +6,7 @@
 
 ### Load the Data
 
-For fast reactions, e.g., reactions occuring during the first minutes of cement hydration, the thermal inertia of the calorimeter significantly broadens the heat flow signal. 
+For fast reactions, e.g., reactions occurring during the first minutes of cement hydration, the thermal inertia of the calorimeter significantly broadens the heat flow signal. 
 If the characteristic time constants are determined experimentally, a Tian correction can be applied to the heat flow data.
 
 <!-- Assuming the file structure outlined above, we can apply the Tian correction using the following code.
@@ -45,7 +45,7 @@ The numeric value needs to be determined experimentally.
 
 ```python
 
-# Set Proceesing Parameters
+# Set Processing Parameters
 processparams = ProcessingParameters()
 processparams.time_constants.tau1 = 240
 processparams.time_constants.tau2 = 80
@@ -123,11 +123,11 @@ Therefore, the second equation reads like
 \dot{Q}_{Tian}(t) =  \dot{Q}(t) + (\tau_1+\tau_2) \frac{\dot{Q}}{dt} + \tau_1\tau_2 \frac{d^2\dot{Q}}{dt^2} 
 \]
 
-In pratical terms, if only the attribute tau1 is set, only the first derivative of the heat flow will be considered.
+In practical terms, if only the attribute tau1 is set, only the first derivative of the heat flow will be considered.
 
 ```python
 
-# Set Proceesing Parameters
+# Set Processing Parameters
 processparams = ProcessingParameters()
 processparams.time_constants.tau1 = 300
 ```
@@ -144,13 +144,13 @@ In general, having two tau constants renders the signal even more narrow.
 ### No smoothing
 It is important to smoothen the data. 
 Otherwise, small noise in the raw heat flow data will lead to significant noise especially in the second derivative.
-By default the smoothing is no applied. 
+By default the smoothing is not applied. 
 Here, we explicitly set the attributes to `False` and repeat the analysis as shown above.
 The results demonstrates the noise in the data which originates from tiny fluctuations which result in significant noise in the second derivative.
 
 ```python
 
-# Set Proceesing Parameters
+# Set Processing Parameters
 processparams.median_filter.apply = False
 processparams.spline_interpolation.apply = False
 ```
@@ -164,7 +164,7 @@ Here is the result of only applying a [median filter](https://docs.scipy.org/doc
 
 ```python
 
-# Set Proceesing Parameters
+# Set Processing Parameters
 processparams.median_filter.apply = True
 processparams.median_filter.size = 15
 processparams.spline_interpolation.apply = False
@@ -173,12 +173,12 @@ processparams.spline_interpolation.apply = False
 
 ### Only Spline Smoothing
 
-Here is the result of only applying a [Univariate Spline](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.UnivariateSpline.html#scipy.interpolate.UnivariateSpline) with smmothing of 1e-10 for both the first and the second derivative.
+Here is the result of only applying a [Univariate Spline](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.UnivariateSpline.html#scipy.interpolate.UnivariateSpline) with smoothing of 1e-10 for both the first and the second derivative.
 The combination of a median filter and spline smoothing reliably delivers smooth data without introducing artifacts or significant line broadening.
 
 ```python
 
-# Set Proceesing Parameters
+# Set Processing Parameters
 processparams.median_filter.apply = False
 processparams.spline_interpolation.apply = True
 processparams.spline_interpolation.smoothing_1st_deriv = 1e-10


### PR DESCRIPTION
## Summary
                                                                                                                                                         
  Three small, focused fixes to the docs site after the package was renamed from `TAInstCalorimetry` to `CaloCem`:                                     
                                                                                                                                                         
  - **`docs/index.md`** — wrong package name, "packaga" typo, dead PyPI link (`tainstcalorimetry` → 404).
  - **`docs/quantification.md` and `docs/tian.md`** — handful of typos (`Proceesing`, `inistantiate`, `pratical`, `smmothing`, `occuring`, `is no applied`).                                                                                                                                           
  - **`docs/how-to-guide.md`** — image URLs pointed at the renamed `mj-hofmann/TAInstCalorimetry` repo, badge URLs pointed at the dead   `tainstcalorimetry` PyPI/pepy.tech project, body text and install instruction still used the old name.                                               
                                                                                                                                                         
  No content was rewritten. No design choices were made.                                      
                                                                                                                                                         
  ## Out of scope (intentional)
                                                                                                                                                         
  - **License inconsistency** — `pyproject.toml` says `license = "MIT"` while `LICENSE`, `README.md`, and `docs/how-to-guide.md` all say GPLv3. The  how-to-guide's `## License` section was *not* changed in this PR; it still matches `LICENSE` and `README`. Resolving the structural MIT/GPLv3  contradiction is a maintainer decision and belongs in its own PR.                                                                            
  - **`how-to-guide.md` restructure** — `docs/index.md` labels this "An Older How-To Guide." Whether to fix it further or replace it with new tutorials   is the next docs PR.                                                                                                                                 
  - **Stray local files** in `docs/` (`_data.pickle`, `_info.pickle`, `CaloCem.log`) — already covered by `.gitignore`; they exist only on local working  copies and don't affect the repo.                                                                                                                     
                                                                                                                                                         
  ## Test plan    
                                                                                                                                                         
  - [x] `grep -i tainstcalorimetry docs/` returns no matches.
  - [x] All image asset paths in `docs/how-to-guide.md` exist in `tests/plots/` (verified via `git ls-files`).                                           
  - [x] No code or test files touched; `pytest` baseline unchanged.                                           
  - [ ] Reviewer: render with `mkdocs serve` to confirm no formatting regressions.      