### PR TITLE
Documentation notebooks are tested under pytest via nbmake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "mkdocstrings[python]>=0.30.1",
     "mkdocs-jupyter>=0.25.1",
+    "nbmake>=1.5",
     "calocem",
 ]
 
@@ -75,8 +76,8 @@ warn_unused_configs = true
 no_implicit_reexport = true
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
-addopts = "-q"
+testpaths = ["tests", "docs"]
+addopts = "-q --nbmake"
 
 
 [tool.tox]

--- a/uv.lock
+++ b/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "calocem"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },
@@ -125,6 +125,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocs-table-reader-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "nbmake" },
     { name = "pysnooper" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -156,6 +157,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.5.28" },
     { name = "mkdocs-table-reader-plugin", specifier = ">=2.2.2" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30.1" },
+    { name = "nbmake", specifier = ">=1.5" },
     { name = "pysnooper", specifier = ">=1.1.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
@@ -1661,6 +1663,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
+name = "nbmake"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "pygments" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/9a/aae201cee5639e1d562b3843af8fd9f8d018bb323e776a2b973bdd5fc64b/nbmake-1.5.5.tar.gz", hash = "sha256:239dc868ea13a7c049746e2aba2c229bd0f6cdbc6bfa1d22f4c88638aa4c5f5c", size = 85929, upload-time = "2024-12-23T18:33:46.774Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/b257e12f9710819fde40adc972578bee6b72c5992da1bc8369bef2597756/nbmake-1.5.5-py3-none-any.whl", hash = "sha256:c6fbe6e48b60cacac14af40b38bf338a3b88f47f085c54ac5b8639ff0babaf4b", size = 12818, upload-time = "2024-12-23T18:33:44.566Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary                                                                                                                                             
            
  Wire up `nbmake` so every Jupyter notebook in `docs/` is executed end-to-end as part of `pytest`. With this gate in place, future tutorial notebooks   can't silently rot — any breakage from API changes or missing fixtures shows up as a failed test.                                                      
                                                                                                   
  ## Changes                                                                                                                                             
                                                                                                                                                         
  - Add `nbmake>=1.5` to the `dev` dependency group.
  - Extend `tool.pytest.ini_options.testpaths` to include `docs/`.                                                                                       
  - Add `--nbmake` to `addopts`.                                                                                                                       
                                                                                                                                                         
  That's the whole change — three lines in `pyproject.toml` plus the `uv.lock` update.
                                                                                                                                                         
  ## What this gives you                                                                                                                               
                                                                                                                                                         
  - `uv run pytest` now runs the existing 19 unit tests **plus** executes `docs/plotting_example.ipynb`.                                               
  - The existing `run-tests.yml` workflow runs `uv run pytest`, so the matrix (Python 3.10/3.11/3.12/3.13 × ubuntu/windows/macos) automatically picks up the new gate without any workflow change.                                                                                                             
  - Any future notebook added under `docs/` is automatically tested.                                                                                     
                                                                    
  ## Test plan                                                                                                                                           
                  
  - [x] `uv sync --dev` installs `nbmake==1.5.5`.                                                                                                        
  - [x] `uv run pytest --collect-only` shows `docs/plotting_example.ipynb` in test collection.                                                           
  - [x] `uv run pytest` passes locally: 20 tests in ~7.5s (19 unit + 1 notebook).             
  - [ ] Reviewer: confirm the matrix runs are green on Windows/macOS — notebook execution can be flaky there for matplotlib backend reasons. If a runner  fails, the fix is usually `MPLBACKEND=Agg` as a workflow env var.          