### PR TITLE
 ci(docs): install project + runtime deps to fix notebook execution

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -24,23 +24,15 @@ jobs:
         version: "latest"
 
     - name: Install dependencies
-      run: |
-        uv pip install --system mkdocs
-        uv pip install --system "mkdocstrings[python]"
-        uv pip install --system mkdocs-material
-        uv pip install --system mkdocs-git-revision-date-localized-plugin
-        uv pip install --system mkdocs-git-committers-plugin-2
-        uv pip install --system mkdocs-git-authors-plugin
-        uv pip install --system mkdocs-table-reader-plugin
-        uv pip install --system mkdocs-jupyter
+      run: uv sync --frozen
 
     - name: Build MkDocs
-      run: mkdocs build
+      run: uv run mkdocs build
 
     - name: Deploy to GitHub Pages
       run: |
         git config --global user.email "actions@github.com"
         git config --global user.name "GitHub Actions"
-        mkdocs gh-deploy --force
+        uv run mkdocs gh-deploy --force
         
    


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  Fixes the broken docs deploy where `plotting_example.html` renders `ModuleNotFoundError: No module named 'matplotlib'` tracebacks instead of plots.                                         
                                                                                                                                                                                              
  ## Root cause                                                                                                                                                                               
                  
  PR #45 (`e006b3f`) enabled `execute: True` for the `mkdocs-jupyter` plugin, so notebooks are now re-executed at build time:                                                                 
  
  ```yaml                                                                                                                                                                                     
  plugins:        
    - mkdocs-jupyter:
        no_input: False
        execute: True
  ```

  The deploy workflow, however, still only installed `mkdocs` and a handful of plugins via `uv pip install --system` — it never installed `calocem` itself or runtime deps like `matplotlib`   and `pandas`. Notebook cells therefore failed on `import` and the resulting tracebacks were rendered straight into the deployed HTML.
                                                                                                                                                                                              
  The current live page on `gh-pages` shows three such tracebacks where plots should be:                                                                                                      
  
  ```                                                                                                                                                                                         
  ModuleNotFoundError                       Traceback (most recent call last)
  Cell In[1], line 1
  ----> 1 import matplotlib.pyplot as plt                                                                                                                                                     
  
  ModuleNotFoundError: No module named 'matplotlib'                                                                                                                                           
  ```                                                                                                                                                                                         
  
  ## Fix                                                                                                                                                                                      
                  
  Replace the eight redundant `uv pip install --system` lines (those plugins are already declared in the `dev` group of `pyproject.toml`) with a single `uv sync --frozen`, and invoke mkdocs  via `uv run`. This installs the project plus every dev dep from the lockfile, so notebook execution at build time has access to `calocem` and all its runtime dependencies.
                                                                                                                                                                                              
  ## Verification 

  After this change, `uv run mkdocs build` produces a `plotting_example.html` containing the rendered plots and no traceback strings.       